### PR TITLE
improvement: add telemetry from Pavex server crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2026,7 +2026,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shuttle"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "dotenvy",

--- a/shuttle/Cargo.toml
+++ b/shuttle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 
 [dependencies]

--- a/shuttle/src/main.rs
+++ b/shuttle/src/main.rs
@@ -5,12 +5,17 @@ mod shuttle_pavex;
 
 // dependencies
 use pavex::server::Server;
+use server::telemetry::{get_subscriber, init_telemetry};
 use shuttle_pavex::PavexService;
 use shuttle_runtime::SecretStore;
 use std::env::set_var;
 
 #[shuttle_runtime::main]
 async fn pavex(#[shuttle_runtime::Secrets] secrets: SecretStore) -> shuttle_pavex::ShuttlePavex {
+    // this unsafe block is needed as of Rust 2024, as it's been deemed that modifying a running 
+    // process is potentially unsafe. This step is necessary because Pavex utilizes environment
+    // variables for configuration, and Shuttle does not yet have a container wide way of setting
+    // environment variables.
     unsafe {
         set_var(
             "APP_PROFILE",
@@ -19,6 +24,10 @@ async fn pavex(#[shuttle_runtime::Secrets] secrets: SecretStore) -> shuttle_pave
     }
 
     let _ = dotenvy::dotenv();
+
+    // start up telemetry
+    let subscriber = get_subscriber("pavex_shuttle".into(), "info".into(), std::io::stdout);
+    init_telemetry(subscriber)?;
 
     let server = Server::new();
 


### PR DESCRIPTION
These changes enable tracing the same as in the non-Shuttle binary.